### PR TITLE
Flushing DataOutputStream before calling toByteArray on the underlying ByteArrayOutputStream

### DIFF
--- a/src/test/java/com/flowpowered/nbt/stream/EndianSwitchableStreamTest.java
+++ b/src/test/java/com/flowpowered/nbt/stream/EndianSwitchableStreamTest.java
@@ -44,6 +44,7 @@ public class EndianSwitchableStreamTest {
         EndianSwitchableOutputStream output = new EndianSwitchableOutputStream(rawOutput, ByteOrder.LITTLE_ENDIAN);
         output.writeShort(unsigned);
         output.writeChar(testChar);
+        output.flush();
 
         EndianSwitchableInputStream input = new EndianSwitchableInputStream(new ByteArrayInputStream(rawOutput.toByteArray()), ByteOrder.LITTLE_ENDIAN);
         assertEquals(unsigned, input.readUnsignedShort());


### PR DESCRIPTION
`EndianSwitchableOutputStream.java`  internally uses DataOutputStream as its stream and when a DataOutputStream instance wraps an underlying ByteArrayOutputStream instance,
it is recommended to flush or close the DataOutputStream before invoking the underlying instances's toByteArray(). Also, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a flush method before calling toByteArray().
