### PR TITLE
Array tag fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 processResources {
     // Include in final JAR
     from(rootProject.rootDir) {
-        include 'LICENSE.txt'
+        include 'flownbt-LICENSE.txt'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ version = '1.0.1-SNAPSHOT'
 ext.packaging = 'jar'
 ext.inceptionYear = '2011'
 ext.url = 'https://flowpowered.com/nbt'
-ext.description = 'Named Binary Tag (NBT) library for Java based on Graham Edgecombe's JNBT library.'
+ext.description = 'Named Binary Tag (NBT) library for Java based on Graham Edgecombe\'s JNBT library.'
 
 // Organization information
 ext.organization = 'Flow Powered'

--- a/flownbt-LICENSE.txt
+++ b/flownbt-LICENSE.txt
@@ -1,3 +1,5 @@
+This license document applies to the com.flowpowered package and its subpackages.
+
 The MIT License (MIT)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/main/java/com/flowpowered/nbt/ByteArrayTag.java
+++ b/src/main/java/com/flowpowered/nbt/ByteArrayTag.java
@@ -55,7 +55,9 @@ public final class ByteArrayTag extends Tag<byte[]> {
         StringBuilder hex = new StringBuilder();
         for (byte b : value) {
             String hexDigits = Integer.toHexString(b).toUpperCase();
-            if (hexDigits.length() == 1) {
+            if (hexDigits.length() > 2)
+                hexDigits = hexDigits.substring(hexDigits.length() - 2);
+            else if (hexDigits.length() == 1) {
                 hex.append("0");
             }
             hex.append(hexDigits).append(" ");

--- a/src/main/java/com/flowpowered/nbt/ShortArrayTag.java
+++ b/src/main/java/com/flowpowered/nbt/ShortArrayTag.java
@@ -52,8 +52,19 @@ public class ShortArrayTag extends Tag<short[]> {
         StringBuilder hex = new StringBuilder();
         for (short s : value) {
             String hexDigits = Integer.toHexString(s).toUpperCase();
-            if (hexDigits.length() == 1) {
-                hex.append("0");
+            switch (hexDigits.length()) {
+                case 8:
+                case 7:
+                case 6:
+                case 5:
+                    hexDigits = hexDigits.substring(hexDigits.length() - 4);
+                    break;
+                case 1:
+                    hex.append("0");
+                case 2:
+                    hex.append("0");
+                case 3:
+                    hex.append("0");
             }
             hex.append(hexDigits).append(" ");
         }
@@ -89,7 +100,7 @@ public class ShortArrayTag extends Tag<short[]> {
             int length = shortArray.length;
             short[] newArray = new short[length];
             System.arraycopy(shortArray, 0, newArray, 0, length);
-            return shortArray;
+            return newArray;
         }
     }
 }


### PR DESCRIPTION
Fix ByteArrayTag.toString() and ShortArrayTag.toString() having extra digits for negative numbers or having too few leading zeros for small positive numbers
Fix ShortArrayTag.clone() returning the original array instead of the clone
