### PR TITLE
Improved stream compression

### DIFF
--- a/src/main/java/com/flowpowered/nbt/CompoundMap.java
+++ b/src/main/java/com/flowpowered/nbt/CompoundMap.java
@@ -117,7 +117,7 @@ public class CompoundMap implements Map<String, Tag<?>>, Iterable<Tag<?>> {
             }
         }
         if (initial != null) {
-            for (Tag t : initial) {
+            for (Tag<?> t : initial) {
                 put(t);
             }
         }
@@ -205,8 +205,8 @@ public class CompoundMap implements Map<String, Tag<?>>, Iterable<Tag<?>> {
             Iterator<Tag<?>> iThis = iterator();
             Iterator<Tag<?>> iOther = other.iterator();
             while (iThis.hasNext() && iOther.hasNext()) {
-                Tag tThis = iThis.next();
-                Tag tOther = iOther.next();
+                Tag<?> tThis = iThis.next();
+                Tag<?> tOther = iOther.next();
                 if (!tThis.equals(tOther)) {
                     return false;
                 }

--- a/src/main/java/com/flowpowered/nbt/CompoundTag.java
+++ b/src/main/java/com/flowpowered/nbt/CompoundTag.java
@@ -59,14 +59,15 @@ public class CompoundTag extends Tag<CompoundMap> {
 
         StringBuilder bldr = new StringBuilder();
         bldr.append("TAG_Compound").append(append).append(": ").append(value.size()).append(" entries\r\n{\r\n");
-        for (Tag entry : value.values()) {
+        for (Tag<?> entry : value.values()) {
             bldr.append("   ").append(entry.toString().replaceAll("\r\n", "\r\n   ")).append("\r\n");
         }
         bldr.append("}");
         return bldr.toString();
     }
 
-    public CompoundTag clone() {
+    @Override
+	public CompoundTag clone() {
         CompoundMap map = new CompoundMap(value);
         return new CompoundTag(getName(), map);
     }

--- a/src/main/java/com/flowpowered/nbt/ListTag.java
+++ b/src/main/java/com/flowpowered/nbt/ListTag.java
@@ -77,14 +77,15 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> {
 
         StringBuilder bldr = new StringBuilder();
         bldr.append("TAG_List").append(append).append(": ").append(value.size()).append(" entries of type ").append(TagType.getByTagClass(type).getTypeName()).append("\r\n{\r\n");
-        for (Tag t : value) {
+        for (Tag<?> t : value) {
             bldr.append("   ").append(t.toString().replaceAll("\r\n", "\r\n   ")).append("\r\n");
         }
         bldr.append("}");
         return bldr.toString();
     }
 
-    @SuppressWarnings ("unchecked")
+    @Override
+	@SuppressWarnings ("unchecked")
     public ListTag<T> clone() {
         List<T> newList = new ArrayList<T>();
 

--- a/src/main/java/com/flowpowered/nbt/NBTTester.java
+++ b/src/main/java/com/flowpowered/nbt/NBTTester.java
@@ -60,7 +60,7 @@ public class NBTTester {
         }
 
         try {
-            Tag tag = input.readTag();
+            Tag<?> tag = input.readTag();
             System.out.println("NBT data from file: " + argFile.getCanonicalPath());
             System.out.println(tag);
         } catch (IOException e) {

--- a/src/main/java/com/flowpowered/nbt/Tag.java
+++ b/src/main/java/com/flowpowered/nbt/Tag.java
@@ -107,7 +107,7 @@ public abstract class Tag<T> implements Comparable<Tag<?>> {
     }
 
     @Override
-    public int compareTo(Tag other) {
+    public int compareTo(Tag<?> other) {
         if (equals(other)) {
             return 0;
         } else {
@@ -124,5 +124,6 @@ public abstract class Tag<T> implements Comparable<Tag<?>> {
      *
      * @return the clone
      */
-    public abstract Tag<T> clone();
+    @Override
+	public abstract Tag<T> clone();
 }

--- a/src/main/java/com/flowpowered/nbt/exception/InvalidTagException.java
+++ b/src/main/java/com/flowpowered/nbt/exception/InvalidTagException.java
@@ -26,7 +26,10 @@ package com.flowpowered.nbt.exception;
 import com.flowpowered.nbt.Tag;
 
 public class InvalidTagException extends Exception {
-    public InvalidTagException(Tag t) {
+
+	private static final long serialVersionUID = -5446188798223632410L;
+
+	public InvalidTagException(Tag<?> t) {
         System.out.println("Invalid tag: " + t.toString() + " encountered!");
     }
 }

--- a/src/main/java/com/flowpowered/nbt/gui/NBTViewer.java
+++ b/src/main/java/com/flowpowered/nbt/gui/NBTViewer.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.swing.JFrame;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
@@ -99,7 +100,8 @@ public class NBTViewer extends JFrame implements ActionListener {
 
     public static void main(String[] args) {
         SwingUtilities.invokeLater(new Runnable() {
-            public void run() {
+            @Override
+			public void run() {
                 try {
                     UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
                 } catch (ClassNotFoundException e) {
@@ -141,12 +143,12 @@ public class NBTViewer extends JFrame implements ActionListener {
     }
 
     private List<Tag<?>> readFile(File f) {
-        List<Tag<?>> tags = readRawNBT(f, true);
+        List<Tag<?>> tags = readRawNBT(f, NBTInputStream.GZIP_COMPRESSION);
         if (tags != null) {
             format = "Compressed NBT";
             return tags;
         }
-        tags = readRawNBT(f, false);
+        tags = readRawNBT(f, NBTInputStream.NO_COMPRESSION);
         if (tags != null) {
             format = "Uncompressed NBT";
             return tags;
@@ -166,11 +168,11 @@ public class NBTViewer extends JFrame implements ActionListener {
         return null;
     }
 
-    private List<Tag<?>> readRawNBT(File f, boolean compressed) {
+    private List<Tag<?>> readRawNBT(File f, int compression) {
         List<Tag<?>> tags = new ArrayList<Tag<?>>();
         try {
             InputStream is = new FileInputStream(f);
-            NBTInputStream ns = new NBTInputStream(is, compressed);
+            NBTInputStream ns = new NBTInputStream(is, compression);
             try {
                 boolean eof = false;
                 while (!eof) {

--- a/src/main/java/com/flowpowered/nbt/holder/FieldHolder.java
+++ b/src/main/java/com/flowpowered/nbt/holder/FieldHolder.java
@@ -67,22 +67,44 @@ public abstract class FieldHolder {
         }
     }
 
+    @Deprecated
     public void save(File file, boolean compressed) throws IOException {
         save(new FileOutputStream(file), compressed);
     }
 
-    public void save(OutputStream stream, boolean compressed) throws IOException {
-        NBTOutputStream os = new NBTOutputStream(stream, compressed);
-        os.writeTag(new CompoundTag("", save()));
+    public void save(File file, int compression) throws IOException {
+        save(new FileOutputStream(file), compression);
     }
 
+    @Deprecated
+    public void save(OutputStream stream, boolean compressed) throws IOException {
+    	save(stream, compressed ? NBTInputStream.GZIP_COMPRESSION : NBTInputStream.NO_COMPRESSION);
+    }
+
+    public void save(OutputStream stream, int compression) throws IOException {
+        NBTOutputStream os = new NBTOutputStream(stream, compression);
+        os.writeTag(new CompoundTag("", save()));
+        os.close();
+    }
+
+    @Deprecated
     public void load(File file, boolean compressed) throws IOException {
         load(new FileInputStream(file), compressed);
     }
 
+    public void load(File file, int compression) throws IOException {
+        load(new FileInputStream(file), compression);
+    }
+
+    @Deprecated
     public void load(InputStream stream, boolean compressed) throws IOException {
-        NBTInputStream is = new NBTInputStream(stream, compressed);
+    	load(stream, compressed ? NBTInputStream.GZIP_COMPRESSION : NBTInputStream.NO_COMPRESSION);
+    }
+
+    public void load(InputStream stream, int compression) throws IOException {
+        NBTInputStream is = new NBTInputStream(stream, compression);
         Tag<?> tag = is.readTag();
+        is.close();
         if (!(tag instanceof CompoundTag)) {
             throw new IllegalArgumentException("Expected CompoundTag, got " + tag.getClass());
         }

--- a/src/main/java/com/flowpowered/nbt/holder/FieldValue.java
+++ b/src/main/java/com/flowpowered/nbt/holder/FieldValue.java
@@ -53,7 +53,7 @@ public class FieldValue<T> {
      * @return The value
      */
     public T load(CompoundTag tag) {
-        Tag subTag = tag.getValue().get(key);
+        Tag<?> subTag = tag.getValue().get(key);
         if (subTag == null) {
             return (value = defaultValue);
         }
@@ -67,7 +67,7 @@ public class FieldValue<T> {
                 return;
             }
         }
-        Tag t = field.getValue(key, value);
+        Tag<?> t = field.getValue(key, value);
         tag.put(t);
     }
 

--- a/src/main/java/com/flowpowered/nbt/itemmap/StringMapReader.java
+++ b/src/main/java/com/flowpowered/nbt/itemmap/StringMapReader.java
@@ -38,9 +38,8 @@ public class StringMapReader {
     public static List<Tag<?>> readFile(File f) {
         List<Tag<?>> list = new ArrayList<Tag<?>>();
 
-        try {
-            FileInputStream fis = new FileInputStream(f);
-            DataInputStream dis = new DataInputStream(fis);
+        try (FileInputStream fis = new FileInputStream(f);
+            DataInputStream dis = new DataInputStream(fis);){
             boolean eof = false;
             while (!eof) {
                 int value;

--- a/src/main/java/com/flowpowered/nbt/regionfile/SimpleRegionFileReader.java
+++ b/src/main/java/com/flowpowered/nbt/regionfile/SimpleRegionFileReader.java
@@ -77,7 +77,7 @@ public class SimpleRegionFileReader {
                 raf.readFully(data);
                 ByteArrayInputStream in = new ByteArrayInputStream(data);
                 InflaterInputStream iis = new InflaterInputStream(in);
-                NBTInputStream ns = new NBTInputStream(iis, false);
+                NBTInputStream ns = new NBTInputStream(iis, NBTInputStream.NO_COMPRESSION);
                 try {
                     Tag<?> t = ns.readTag();
                     list.add(t);

--- a/src/main/java/com/flowpowered/nbt/stream/NBTOutputStream.java
+++ b/src/main/java/com/flowpowered/nbt/stream/NBTOutputStream.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPOutputStream;
 
 import com.flowpowered.nbt.ByteArrayTag;
@@ -73,9 +74,23 @@ public final class NBTOutputStream implements Closeable {
      * @param os The output stream.
      * @param compressed A flag that indicates if the output should be compressed.
      * @throws java.io.IOException if an I/O error occurs.
+     * @deprecated Use {@link #NBTOutputStream(InputStream, int)} instead
      */
+    @Deprecated
     public NBTOutputStream(OutputStream os, boolean compressed) throws IOException {
         this(os, compressed, ByteOrder.BIG_ENDIAN);
+    }
+
+    /**
+     * Creates a new {@link NBTOutputStream}, which will write data to the specified underlying output stream. The stream may be wrapped into a compressing output stream
+     * depending on the chosen compression method. A flag indicates if the output should be compressed with GZIP or not.
+     *
+     * @param os The output stream.
+     * @param compression The compression algorithm used for the input stream. Must be {@link NBTInputStream#NO_COMPRESSION}, {@link NBTInputStream#GZIP_COMPRESSION} or {@link NBTInputStream#ZLIB_COMPRESSION}.
+     * @throws java.io.IOException if an I/O error occurs.
+     */
+    public NBTOutputStream(OutputStream os, int compression) throws IOException {
+        this(os, compression, ByteOrder.BIG_ENDIAN);
     }
 
     /**
@@ -85,9 +100,35 @@ public final class NBTOutputStream implements Closeable {
      * @param compressed A flag that indicates if the output should be compressed.
      * @param endianness A flag that indicates if numbers in the output should be output in little-endian format.
      * @throws java.io.IOException if an I/O error occurs.
+     * @deprecated Use {@link #NBTOutputStream(InputStream, int, ByteOrder)} instead
      */
+    @Deprecated
     public NBTOutputStream(OutputStream os, boolean compressed, ByteOrder endianness) throws IOException {
-        this.os = new EndianSwitchableOutputStream(compressed ? new GZIPOutputStream(os) : os, endianness);
+        this(os, compressed ? NBTInputStream.GZIP_COMPRESSION : NBTInputStream.NO_COMPRESSION, endianness);
+    }
+
+    /**
+     * Creates a new {@link NBTOutputStream}, which will write data to the specified underlying output stream. The stream may be wrapped into a compressing output stream depending on the chosen compression method.
+     *
+     * @param os The output stream.
+     * @param compression The compression algorithm used for the input stream. Must be {@link NBTInputStream#NO_COMPRESSION}, {@link NBTInputStream#GZIP_COMPRESSION} or {@link NBTInputStream#ZLIB_COMPRESSION}.
+     * @param endianness A flag that indicates if numbers in the output should be output in little-endian format.
+     * @throws java.io.IOException if an I/O error occurs.
+     */
+    public NBTOutputStream(OutputStream os, int compression, ByteOrder endianness) throws IOException {
+    	switch (compression) {
+    	case NBTInputStream.NO_COMPRESSION:
+    		this.os = new EndianSwitchableOutputStream(os, endianness);
+    		break;
+    	case NBTInputStream.GZIP_COMPRESSION:
+    		this.os = new EndianSwitchableOutputStream(new GZIPOutputStream(os), endianness);
+    		break;
+    	case NBTInputStream.ZLIB_COMPRESSION:
+    		this.os = new EndianSwitchableOutputStream(new DeflaterOutputStream(os), endianness);
+    		break;
+    	default:
+    		throw new IllegalArgumentException("Unsupported compression type, must be between 0 and 2 (inclusive)");
+    	}
     }
 
     /**
@@ -329,7 +370,8 @@ public final class NBTOutputStream implements Closeable {
         /* empty */
     }
 
-    public void close() throws IOException {
+    @Override
+	public void close() throws IOException {
         os.close();
     }
 

--- a/src/main/java/com/flowpowered/nbt/stream/NBTOutputStream.java
+++ b/src/main/java/com/flowpowered/nbt/stream/NBTOutputStream.java
@@ -65,7 +65,7 @@ public final class NBTOutputStream implements Closeable {
      * @throws java.io.IOException if an I/O error occurs.
      */
     public NBTOutputStream(OutputStream os) throws IOException {
-        this(os, true, ByteOrder.BIG_ENDIAN);
+        this(os, NBTInputStream.GZIP_COMPRESSION, ByteOrder.BIG_ENDIAN);
     }
 
     /**

--- a/src/test/java/com/flowpowered/nbt/stream/EndianSwitchableStreamTest.java
+++ b/src/test/java/com/flowpowered/nbt/stream/EndianSwitchableStreamTest.java
@@ -23,14 +23,14 @@
  */
 package com.flowpowered.nbt.stream;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test for both {@link EndianSwitchableInputStream EndianSwitchableInput} and {@link EndianSwitchableOutputStream Output} Streams
@@ -44,9 +44,11 @@ public class EndianSwitchableStreamTest {
         EndianSwitchableOutputStream output = new EndianSwitchableOutputStream(rawOutput, ByteOrder.LITTLE_ENDIAN);
         output.writeShort(unsigned);
         output.writeChar(testChar);
+        output.close();
 
         EndianSwitchableInputStream input = new EndianSwitchableInputStream(new ByteArrayInputStream(rawOutput.toByteArray()), ByteOrder.LITTLE_ENDIAN);
         assertEquals(unsigned, input.readUnsignedShort());
         assertEquals(testChar, input.readChar());
+        input.close();
     }
 }


### PR DESCRIPTION
The `NBTi/oStream`s only provide a boolean flag to tell if the stream is compressed or not. In reality, there are three possible compressions: none, gzip or zlib. The latter one is heavily used to store Chunk NBT data in Minecraft.

This commit introduces three constants for the compression. They happen to be matching the ID convention used by Minecraft. This way, no additional case checking is required to handle the stream compression when reading region files.

The old methods using a boolean are marked as deprecated from now on, since they are ambiguous about which compression algorithm is meant.